### PR TITLE
Jenkins 35420

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.480</version>
+    <version>1.480.3</version>
   </parent>
 
   <artifactId>junit-realtime-test-reporter</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/junitrealtimetestreporter/Attacher.java
+++ b/src/main/java/org/jenkinsci/plugins/junitrealtimetestreporter/Attacher.java
@@ -40,7 +40,9 @@ public class Attacher extends RunListener<Run<?, ?>> {
 
     @Override
     public void onStarted(Run<?, ?> run, TaskListener listener) {
-
+        if ( !( run instanceof AbstractBuild )) {
+            return;
+        }
         final AbstractBuild<?, ?> build = (AbstractBuild<?, ?>) run;
 
         if (!isApplicable(build)) return;


### PR DESCRIPTION
This is not an actual fix to JENKINS-35420. However it prevents unnecessary exceptions in cases when passed run is not support (not an instance of AbstractBuild class).